### PR TITLE
Release via tanem/release-action

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+# Categories for GitHub's generated release notes, keyed by the same labels the
+# release reads to derive the semver bump. `safe to test` authorises CI runs and
+# says nothing about the release, so it is excluded from both.
+changelog:
+  exclude:
+    labels:
+      - safe to test
+  categories:
+    - title: 💥 Breaking Changes
+      labels:
+        - breaking
+    - title: 🚀 Enhancements
+      labels:
+        - enhancement
+    - title: 🛠 Everything Else
+      labels:
+        - '*'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,48 +1,43 @@
 name: Release
 
+# The filename is load-bearing: npm's trusted publisher for this package
+# matches on repo + workflow filename, so renaming this file means updating the
+# publisher first.
+
 on:
   schedule:
     - cron: '0 9 * * 1' # Every Monday at 9:00 AM UTC
   workflow_dispatch:
-    branches:
-      - master
 
 permissions:
   contents: write
   id-token: write
-  packages: write
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}
 
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+    # The cron only ever fires on the default branch, but a manual dispatch can
+    # target any branch. Without this guard, dispatching against a version
+    # branch would bump, tag and publish that branch to npm as latest.
+    if: github.ref_name == github.event.repository.default_branch
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_TOKEN }}
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: '.nvmrc'
-          check-latest: true
-          registry-url: 'https://registry.npmjs.org'
 
-      - name: Configure git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+      # Load-bearing: prepublishOnly compiles dist/ and needs node_modules, and
+      # the tests gate the release.
+      - run: npm ci
 
-      - name: Install dependencies
-        run: npm ci
+      - run: npm test
 
-      - name: Build
-        run: npm run compile
-
-      - name: Release
-        run: npm run release
-        env:
-          CHANGELOG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: tanem/release-action@29ffc8b4e3956c1b9532bfb2ad863f31953354a4 # v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+This file is frozen history: it covers releases up to and including v1.17.21,
+and is not regenerated any more. Everything released after that lives on
+[GitHub Releases](https://github.com/tanem/jest-prettyhtml-matchers/releases).
+
 ## [v1.17.21](https://github.com/tanem/jest-prettyhtml-matchers/tree/v1.17.21) (2026-03-02)
 [Full Changelog](https://github.com/tanem/jest-prettyhtml-matchers/compare/v1.17.20...v1.17.21)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "jest-prettyhtml-matchers",
-      "version": "1.17.20",
+      "version": "1.17.21",
       "license": "MIT",
       "dependencies": {
         "@starptech/prettyhtml": "^0.10.0"
@@ -27,7 +27,6 @@
         "jest-snapshot": "30.2.0",
         "npm-run-all2": "8.0.4",
         "prettier": "3.8.1",
-        "tanem-scripts": "8.0.4",
         "ts-jest": "29.4.6",
         "ts-node": "10.9.2",
         "typescript": "5.9.3"
@@ -1419,172 +1418,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@octokit/auth-token": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
-      "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@octokit/core": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
-      "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/auth-token": "^6.0.0",
-        "@octokit/graphql": "^9.0.3",
-        "@octokit/request": "^10.0.6",
-        "@octokit/request-error": "^7.0.2",
-        "@octokit/types": "^16.0.0",
-        "before-after-hook": "^4.0.0",
-        "universal-user-agent": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@octokit/endpoint": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.2.tgz",
-      "integrity": "sha512-4zCpzP1fWc7QlqunZ5bSEjxc6yLAlRTnDwKtgXfcI/FxxGoqedDG8V2+xJ60bV2kODqcGB+nATdtap/XYq2NZQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^16.0.0",
-        "universal-user-agent": "^7.0.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@octokit/graphql": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
-      "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/request": "^10.0.6",
-        "@octokit/types": "^16.0.0",
-        "universal-user-agent": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@octokit/openapi-types": {
-      "version": "27.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
-      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
-      "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^16.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=6"
-      }
-    },
-    "node_modules/@octokit/plugin-request-log": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
-      "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=6"
-      }
-    },
-    "node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
-      "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^16.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=6"
-      }
-    },
-    "node_modules/@octokit/request": {
-      "version": "10.0.7",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.7.tgz",
-      "integrity": "sha512-v93h0i1yu4idj8qFPZwjehoJx4j3Ntn+JhXsdJrG9pYaX6j/XRz2RmasMUHtNgQD39nrv/VwTWSqK0RNXR8upA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/endpoint": "^11.0.2",
-        "@octokit/request-error": "^7.0.2",
-        "@octokit/types": "^16.0.0",
-        "fast-content-type-parse": "^3.0.0",
-        "universal-user-agent": "^7.0.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@octokit/request-error": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
-      "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^16.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@octokit/rest": {
-      "version": "22.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.1.tgz",
-      "integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/core": "^7.0.6",
-        "@octokit/plugin-paginate-rest": "^14.0.0",
-        "@octokit/plugin-request-log": "^6.0.0",
-        "@octokit/plugin-rest-endpoint-methods": "^17.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@octokit/types": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
-      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^27.0.0"
-      }
-    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -2969,13 +2802,6 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
-    "node_modules/before-after-hook": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
-      "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/boxen": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-3.2.0.tgz",
@@ -3581,16 +3407,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3712,17 +3528,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/date-fns": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {
@@ -4467,23 +4272,6 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
-    "node_modules/fast-content-type-parse": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
-      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4752,32 +4540,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/git-remote-origin-url": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-3.1.0.tgz",
-      "integrity": "sha512-yVSfaTMO7Bqk6Xx3696ufNfjdrajX7Ig9GuAeO2V3Ji7stkDoBNFldnWIAsy0qviUd0Z+X2P6ziJENKztW7cBQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "gitconfiglocal": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/gitconfiglocal": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-2.1.0.tgz",
-      "integrity": "sha512-qoerOEliJn3z+Zyn1HW2F6eoYJqKwS6MgC9cztTLUB/xLWX8gD/6T60pKn4+t/d6tP7JlybI7Z3z+I572CR/Vg==",
-      "dev": true,
-      "license": "BSD",
-      "dependencies": {
-        "ini": "^1.3.2"
       }
     },
     "node_modules/glob": {
@@ -6262,13 +6024,6 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/keypress": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.2.1.tgz",
-      "integrity": "sha512-HjorDJFNhnM4SicvaUXac0X77NiskggxJdesG72+O5zBKpSqKFCrqmndKVqpu3pFqkla0St6uGk8Ju0sCurrmg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -6632,24 +6387,6 @@
         "url": "https://opencollective.com/napi-postinstall"
       }
     },
-    "node_modules/native-or-another": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/native-or-another/-/native-or-another-2.0.0.tgz",
-      "integrity": "sha512-rDE50rrX/PSk2StV5EnwpRk35TENl4I4ZsSGZsMJufLdAJ1P4YzNwVf5UOhjQodwz+RdTP9eZSG7FiqnoY25nA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "native-or-bluebird": "^1.1.2"
-      }
-    },
-    "node_modules/native-or-bluebird": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.2.0.tgz",
-      "integrity": "sha512-0SH8UubxDfe382eYiwmd12qxAbiWGzlGZv6CkMA+DPojWa/Y0oH4hE0lRtFfFgJmPQFyKXeB8XxPbZz6TvvKaQ==",
-      "deprecated": "'native-or-bluebird' is deprecated. Please use 'any-promise' instead.",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -7003,19 +6740,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/parse-github-url": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.3.tgz",
-      "integrity": "sha512-tfalY5/4SqGaV/GIGzWyHnFjlpTPTNpENR9Ea2lLldSJ8EWXMsvacWucqY3m3I4YPtas15IxTLQVQ5NSYXPrww==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "parse-github-url": "cli.js"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -7312,17 +7036,6 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
-    },
-    "node_modules/prompt-promise": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/prompt-promise/-/prompt-promise-1.0.3.tgz",
-      "integrity": "sha512-xIbGSzK59hFiwn9kmD0Cki4igpUqTVx7c6D8lqZoENAZyTwxhMhh/QleHWoRFVVusi7CTj/ByHP3N+2EmkhKIA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "keypress": "~0.2.1",
-        "native-or-another": "~2.0.0"
-      }
     },
     "node_modules/property-information": {
       "version": "5.6.0",
@@ -8259,27 +7972,6 @@
         "url": "https://opencollective.com/synckit"
       }
     },
-    "node_modules/tanem-scripts": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/tanem-scripts/-/tanem-scripts-8.0.4.tgz",
-      "integrity": "sha512-8f3qA7SBzNEHdEMfcqka8EAMQBKkSE+xJmsycj8nzUsglDTJrgtwMIrZOwcoso0hYm1NtmPoQWCUvBTlJmtkDw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/rest": "^22.0.1",
-        "commander": "^14.0.3",
-        "date-fns": "^4.1.0",
-        "execa": "^5.1.1",
-        "fs-extra": "^11.3.3",
-        "git-remote-origin-url": "^3.1.0",
-        "parse-github-url": "^1.0.3",
-        "prompt-promise": "^1.0.3",
-        "semver": "^7.7.4"
-      },
-      "bin": {
-        "tanem-scripts": "dist/cli.js"
-      }
-    },
     "node_modules/term-size": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
@@ -9179,13 +8871,6 @@
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
       "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
       "license": "MIT"
-    },
-    "node_modules/universal-user-agent": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
-      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/universalify": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "compile": "tsc -p tsconfig.base.json",
     "format": "prettier --write \"**/*.{mjs,js,ts}\"",
     "lint": "eslint .",
-    "release": "tanem-scripts release",
+    "prepublishOnly": "run-s clean:dist compile",
     "test": "run-s check lint clean compile && ts-node scripts/test"
   },
   "peerDependencies": {
@@ -59,7 +59,6 @@
     "jest-snapshot": "30.2.0",
     "npm-run-all2": "8.0.4",
     "prettier": "3.8.1",
-    "tanem-scripts": "8.0.4",
     "ts-jest": "29.4.6",
     "ts-node": "10.9.2",
     "typescript": "5.9.3"


### PR DESCRIPTION
Replaces the `tanem-scripts` release command with the [`tanem/release-action`](https://github.com/tanem/release-action) composite action, SHA-pinned to v0.1.0 and rolled forward by Renovate. The workflow keeps its filename, which is load-bearing: npm's trusted publisher for this package matches on repo plus workflow filename, so renaming it would need the publisher updated first.

The job is guarded by the default branch. The cron only ever fires there, but `workflow_dispatch` can target any branch, and without the guard one of those would bump, tag and publish that branch to npm as `latest`. It reads the default branch rather than naming one — the form the rest of the fleet and the action's own README now carry. Apart from one comment describing how this repo builds `dist/`, the workflow is now identical to the shape on `react-nprogress`, `react-svg` and `svg-injector`.

`CHANGELOG.md` is frozen at v1.17.21, with GitHub Releases taking over as the canonical changelog, categorised by the same labels that drive the bump via the new `.github/release.yml`.

`prepublishOnly` compiles `dist/` rather than leaving it to whatever the test run happened to leave behind. `test` runs `clean` before `compile`, so a reordering there would otherwise have published an empty `dist/` silently.

## What changed since this PR was first opened

It has been rebased onto master, which now carries the jest matrix work from #1243. Two things that were previously part of this PR are no longer in it, because they landed there instead: the tracked snapshot header that `npm version` would have tripped over, and the matrix repairs that made this repo releasable at all. This PR is now just the release-flow migration.

Verified locally on the rebased branch: `npm test` passes end to end — 12 jest versions, 26 suites, exit 0 — and leaves the working tree clean, which is what `npm version` needs.