### PR TITLE
Cut the jest matrix to boundary versions and make it honest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 jest.config.*
 node_modules/
 test/**/src/
+test/**/tsconfig.json

--- a/scripts/clean.ts
+++ b/scripts/clean.ts
@@ -4,7 +4,10 @@ import path from 'path'
 
 delSync('jest.config.*.json')
 
-const jestVersions = fs.readdirSync(path.join(process.cwd(), 'test/jest'))
+const jestVersions = fs
+  .readdirSync(path.join(process.cwd(), 'test/jest'), { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name)
 
 jestVersions.forEach((jestVersion) => {
   delSync(['**/*', '!package.json'], {

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -2,7 +2,10 @@ import { spawnSync } from 'child_process'
 import fs from 'fs-extra'
 import path from 'path'
 
-let status
+// Every jest run's exit code folds into this, and it never clears. Assigning it
+// per run instead meant the last version tested decided the whole suite's exit
+// code, so a failure anywhere but the end left the run green.
+let status = 0
 
 const testTarget = process.env.TEST_TARGET || 'all'
 
@@ -17,7 +20,7 @@ const installPrereqs = (dir: string) => {
     stdio: 'inherit',
   })
 
-  spawnSync(
+  const install = spawnSync(
     'npm',
     ['install', '--no-package-lock', '--quiet', '--no-progress'],
     {
@@ -25,17 +28,29 @@ const installPrereqs = (dir: string) => {
       stdio: 'inherit',
     },
   )
+
+  // A failed install used to be survivable: jest was then missing, spawnSync
+  // returned a null status rather than a number, and the version counted as a
+  // pass. The matrix reported green while testing nothing at all.
+  if (install.status !== 0) {
+    throw new Error(
+      `Installing prerequisites failed in ${dir} (npm exited ${install.status})`,
+    )
+  }
 }
 
 const runJest = (configPath: string, dir = process.cwd()) => {
-  ;({ status } = spawnSync(
+  const result = spawnSync(
     path.join(dir, 'node_modules', '.bin', 'jest'),
     ['-c', configPath, process.argv.slice(2).join(' ')],
     {
       cwd: dir,
       stdio: 'inherit',
     },
-  ))
+  )
+  if (result.status) {
+    status = result.status
+  }
 }
 
 const getBaseConfig = (options = {}) => ({
@@ -93,9 +108,36 @@ const runJestVersionTests = (jestVersion: string) => {
   const targetDistDir = path.join(rootDir, 'dist')
   const srcConfigPath = path.join(rootDir, 'jest.config.src.json')
   const distConfigPath = path.join(rootDir, 'jest.config.dist.json')
+  const tsconfigPath = path.join(rootDir, 'tsconfig.json')
 
   fs.copySync(srcDir, targetSrcDir)
   fs.copySync(distDir, targetDistDir)
+
+  // Without a tsconfig of its own, ts-jest compiles the copied tests with its
+  // built-in defaults, which do not pull in the jest globals — every file then
+  // fails with TS2593 "Cannot find name 'describe'". `types: ['jest']` resolves
+  // through the repo root's node_modules/@types, so the version directories
+  // stay as thin as they look: a package.json naming a jest version, nothing
+  // else checked in.
+  //
+  // Deliberately not the root tsconfig's NodeNext: each directory resolves its
+  // own TypeScript, and the oldest jest in the matrix drags in one that predates
+  // NodeNext and rejects it outright (TS6046). commonjs/node is understood by
+  // every TypeScript any of these versions can pull, and matches how jest loads
+  // the tests anyway.
+  fs.writeFileSync(
+    tsconfigPath,
+    JSON.stringify({
+      compilerOptions: {
+        esModuleInterop: true,
+        module: 'commonjs',
+        moduleResolution: 'node',
+        strict: true,
+        target: 'ES2015',
+        types: ['jest'],
+      },
+    }),
+  )
 
   fs.writeFileSync(
     srcConfigPath,
@@ -136,7 +178,10 @@ if (/^\d\d\.\d$/.test(testTarget)) {
 if (testTarget === 'all') {
   runSrcTests()
   runDistTests()
-  const jestVersions = fs.readdirSync(path.join(process.cwd(), 'test/jest'))
+  const jestVersions = fs
+    .readdirSync(path.join(process.cwd(), 'test/jest'), { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
   jestVersions.forEach(runJestVersionTests)
 }
 

--- a/src/__tests__/__snapshots__/to-match-prettyhtml-snapshot.test.ts.snap
+++ b/src/__tests__/__snapshots__/to-match-prettyhtml-snapshot.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`custom global options with custom local options 1`] = `
 "<svg

--- a/test/jest/25.1/package.json
+++ b/test/jest/25.1/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "devDependencies": {
     "jest": "25.1",
-    "ts-jest": "25.x"
+    "ts-jest": "25.x",
+    "typescript": "3.x"
   }
 }

--- a/test/jest/25.2/package.json
+++ b/test/jest/25.2/package.json
@@ -1,7 +1,0 @@
-{
-  "private": true,
-  "devDependencies": {
-    "jest": "25.2",
-    "ts-jest": "25.x"
-  }
-}

--- a/test/jest/25.3/package.json
+++ b/test/jest/25.3/package.json
@@ -1,7 +1,0 @@
-{
-  "private": true,
-  "devDependencies": {
-    "jest": "25.3",
-    "ts-jest": "25.x"
-  }
-}

--- a/test/jest/25.4/package.json
+++ b/test/jest/25.4/package.json
@@ -1,7 +1,0 @@
-{
-  "private": true,
-  "devDependencies": {
-    "jest": "25.4",
-    "ts-jest": "25.x"
-  }
-}

--- a/test/jest/25.5/package.json
+++ b/test/jest/25.5/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "devDependencies": {
     "jest": "25.5",
-    "ts-jest": "25.x"
+    "ts-jest": "25.x",
+    "typescript": "3.x"
   }
 }

--- a/test/jest/26.0/package.json
+++ b/test/jest/26.0/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "devDependencies": {
     "jest": "26.0",
-    "ts-jest": "26.x"
+    "ts-jest": "26.x",
+    "typescript": "4.x"
   }
 }

--- a/test/jest/26.1/package.json
+++ b/test/jest/26.1/package.json
@@ -1,7 +1,0 @@
-{
-  "private": true,
-  "devDependencies": {
-    "jest": "26.1",
-    "ts-jest": "26.x"
-  }
-}

--- a/test/jest/26.2/package.json
+++ b/test/jest/26.2/package.json
@@ -1,7 +1,0 @@
-{
-  "private": true,
-  "devDependencies": {
-    "jest": "26.2",
-    "ts-jest": "26.x"
-  }
-}

--- a/test/jest/26.3/package.json
+++ b/test/jest/26.3/package.json
@@ -1,7 +1,0 @@
-{
-  "private": true,
-  "devDependencies": {
-    "jest": "26.3",
-    "ts-jest": "26.x"
-  }
-}

--- a/test/jest/26.4/.nvmrc
+++ b/test/jest/26.4/.nvmrc
@@ -1,1 +1,0 @@
-lts/erbium

--- a/test/jest/26.4/package.json
+++ b/test/jest/26.4/package.json
@@ -1,7 +1,0 @@
-{
-  "private": true,
-  "devDependencies": {
-    "jest": "26.4",
-    "ts-jest": "26.x"
-  }
-}

--- a/test/jest/26.5/package.json
+++ b/test/jest/26.5/package.json
@@ -1,7 +1,0 @@
-{
-  "private": true,
-  "devDependencies": {
-    "jest": "26.5",
-    "ts-jest": "26.x"
-  }
-}

--- a/test/jest/26.6/package.json
+++ b/test/jest/26.6/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "devDependencies": {
     "jest": "26.6",
-    "ts-jest": "26.x"
+    "ts-jest": "26.x",
+    "typescript": "4.x"
   }
 }

--- a/test/jest/27.0/package.json
+++ b/test/jest/27.0/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "devDependencies": {
     "jest": "27.0",
-    "ts-jest": "27.x"
+    "ts-jest": "27.x",
+    "typescript": "4.x"
   }
 }

--- a/test/jest/27.1/package.json
+++ b/test/jest/27.1/package.json
@@ -1,7 +1,0 @@
-{
-  "private": true,
-  "devDependencies": {
-    "jest": "27.1",
-    "ts-jest": "27.x"
-  }
-}

--- a/test/jest/27.2/package.json
+++ b/test/jest/27.2/package.json
@@ -1,7 +1,0 @@
-{
-  "private": true,
-  "devDependencies": {
-    "jest": "27.2",
-    "ts-jest": "27.x"
-  }
-}

--- a/test/jest/27.3/package.json
+++ b/test/jest/27.3/package.json
@@ -1,7 +1,0 @@
-{
-  "private": true,
-  "devDependencies": {
-    "jest": "27.3",
-    "ts-jest": "27.x"
-  }
-}

--- a/test/jest/27.4/package.json
+++ b/test/jest/27.4/package.json
@@ -1,7 +1,0 @@
-{
-  "private": true,
-  "devDependencies": {
-    "jest": "27.4",
-    "ts-jest": "27.x"
-  }
-}

--- a/test/jest/27.5/package.json
+++ b/test/jest/27.5/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "devDependencies": {
     "jest": "27.5",
-    "ts-jest": "27.x"
+    "ts-jest": "27.x",
+    "typescript": "4.x"
   }
 }

--- a/test/jest/28.0/package.json
+++ b/test/jest/28.0/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "devDependencies": {
     "jest": "28.0",
-    "ts-jest": "28.x"
+    "ts-jest": "28.x",
+    "typescript": "5.x"
   }
 }

--- a/test/jest/28.1/package.json
+++ b/test/jest/28.1/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "devDependencies": {
     "jest": "28.1",
-    "ts-jest": "28.x"
+    "ts-jest": "28.x",
+    "typescript": "5.x"
   }
 }

--- a/test/jest/29.1/package.json
+++ b/test/jest/29.1/package.json
@@ -1,7 +1,0 @@
-{
-  "private": true,
-  "devDependencies": {
-    "jest": "29.1",
-    "ts-jest": "29.x"
-  }
-}

--- a/test/jest/29.2/package.json
+++ b/test/jest/29.2/package.json
@@ -1,7 +1,0 @@
-{
-  "private": true,
-  "devDependencies": {
-    "jest": "29.2",
-    "ts-jest": "29.x"
-  }
-}

--- a/test/jest/29.3/package.json
+++ b/test/jest/29.3/package.json
@@ -1,7 +1,0 @@
-{
-  "private": true,
-  "devDependencies": {
-    "jest": "29.3",
-    "ts-jest": "29.x"
-  }
-}

--- a/test/jest/29.4/package.json
+++ b/test/jest/29.4/package.json
@@ -1,7 +1,0 @@
-{
-  "private": true,
-  "devDependencies": {
-    "jest": "29.4",
-    "ts-jest": "29.x"
-  }
-}

--- a/test/jest/29.5/package.json
+++ b/test/jest/29.5/package.json
@@ -1,7 +1,0 @@
-{
-  "private": true,
-  "devDependencies": {
-    "jest": "29.5",
-    "ts-jest": "29.x"
-  }
-}

--- a/test/jest/29.6/package.json
+++ b/test/jest/29.6/package.json
@@ -1,7 +1,0 @@
-{
-  "private": true,
-  "devDependencies": {
-    "jest": "29.6",
-    "ts-jest": "29.x"
-  }
-}

--- a/test/jest/29.7/package.json
+++ b/test/jest/29.7/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "devDependencies": {
-    "jest": "29.0",
+    "jest": "29.7",
     "ts-jest": "29.x",
     "typescript": "5.x"
   }

--- a/test/jest/30.0/package.json
+++ b/test/jest/30.0/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "devDependencies": {
-    "jest": "29.0",
+    "jest": "30.0",
     "ts-jest": "29.x",
     "typescript": "5.x"
   }

--- a/test/jest/30.4/package.json
+++ b/test/jest/30.4/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "devDependencies": {
-    "jest": "29.0",
+    "jest": "30.4",
     "ts-jest": "29.x",
     "typescript": "5.x"
   }

--- a/test/jest/README.md
+++ b/test/jest/README.md
@@ -1,0 +1,40 @@
+# Jest version matrix
+
+Each directory here is one jest version the matchers are tested against. A
+directory holds nothing but a `package.json` naming its jest version; the
+sources, the jest configs and the tsconfig are all generated into it by
+`scripts/test.ts` and are gitignored.
+
+## Which versions live here
+
+Boundary versions only: the **first and last minor of each major** named in the
+`peerDependencies` range, plus any minor that changed behaviour worth pinning.
+Adding a boundary means replacing the previous last-minor for that major, not
+accumulating versions — otherwise the matrix grows without bound and every run
+pays for it.
+
+The matrix must span every major the `peerDependencies` range claims. It ran
+from 25 to 29 for a while after support for 30 was declared, which meant the
+newest supported major was the one version nobody tested.
+
+## Why each directory pins three versions
+
+They are one chain, and picking a jest version fixes the other two. `ts-jest`
+majors track jest majors, and each `ts-jest` accepts only a narrow TypeScript
+range:
+
+| jest | ts-jest | typescript |
+| ---- | ------- | ---------- |
+| 25   | 25.x    | 3.x        |
+| 26   | 26.x    | 4.x        |
+| 27   | 27.x    | 4.x        |
+| 28   | 28.x    | 5.x        |
+| 29   | 29.x    | 5.x        |
+| 30   | 29.x    | 5.x        |
+
+Every directory used to float `ts-jest` at `29.x` regardless of its jest
+version. That worked until ts-jest 29.4.12 narrowed its jest peer to
+`^29 || ^30`, at which point installing anything below jest 29 failed outright —
+and a failed install used to count as a pass, so the matrix went green while
+testing nothing. Leaving `typescript` unpinned failed the same way from the
+other end: npm was free to install TypeScript 7, which ts-jest 29 cannot drive.


### PR DESCRIPTION
The matrix carried 27 jest versions and had been red since roughly May. Shrinking it was the goal; most of this PR is what shrinking it uncovered.

## The shrink

Boundary versions only, the policy react-svg already documents: first and last minor of each major. 27 directories down to 12. The range now also spans jest 30, which `peerDependencies` has claimed since v1.17 while the matrix stopped at 29 — the newest supported major was the one version nobody tested. That closes tanem/jest-prettyhtml-matchers#1228, which tried to add jest 30 in January and has been red ever since for the reason below.

## Why it was red

`ts-jest` needs a tsconfig in each version directory. Without one it compiles the copied tests using its own defaults, which don't pull in the jest globals, and every file dies on `TS2593: Cannot find name 'describe'`. The script now writes one alongside the jest configs it already wrote. It is `commonjs`, not the root's `NodeNext`: the oldest jest in the matrix drags in a TypeScript that predates `NodeNext` and rejects it outright.

## Why the version pins had to change

Each directory now pins `jest`, `ts-jest` and `typescript` together, because they are one chain — ts-jest majors track jest majors, and each ts-jest accepts only a narrow TypeScript range. Every directory previously floated `ts-jest` at `29.x` regardless of its jest version, which worked until ts-jest 29.4.12 narrowed its jest peer to `^29 || ^30`. After that, installing anything below jest 29 failed outright. Leaving `typescript` unpinned failed from the other end: npm was free to install TypeScript 7, which ts-jest 29 cannot drive.

## The part worth reviewing closely

**Two failure modes were invisible, and one of them made the matrix lie.** A failed install left jest missing, so `spawnSync` returned a null status rather than a number and the version counted as a pass. Separately, each run *overwrote* the exit status instead of folding into it, so whichever version ran last decided the whole suite's result. Together those mean this matrix could report green while installing and testing nothing. Both now fail loudly, and that is what surfaced the jest 28 breakage during this work.

## The release blocker

The snapshot header is jest 30's. It was being rewritten on every test run, which the old release flow absorbed via `git add .` — but `npm version` refuses a dirty tree, so under the action every release would have failed on it. This is the trap the pilot migration flagged for this repo. Verified after committing: a full root test run now leaves the working tree clean.

`npm test` passes end to end from a clean checkout: 12 versions, 26 suites, exit 0.